### PR TITLE
Fixed quotation bugs in backups role task files

### DIFF
--- a/roles/backup/tasks/aruba.yml
+++ b/roles/backup/tasks/aruba.yml
@@ -5,4 +5,4 @@
   register: backup_location
 
 - debug:
-    msg: {{ backup_location }}
+    msg: "{{ backup_location }}"

--- a/roles/backup/tasks/eos.yml
+++ b/roles/backup/tasks/eos.yml
@@ -5,4 +5,4 @@
   register: backup_location
 
 - debug:
-    msg: {{ backup_location }}
+    msg: "{{ backup_location }}"

--- a/roles/backup/tasks/ios.yml
+++ b/roles/backup/tasks/ios.yml
@@ -5,4 +5,4 @@
   register: backup_location
 
 - debug:
-    msg: {{ backup_location }}
+    msg: "{{ backup_location }}"

--- a/roles/backup/tasks/iosxr.yml
+++ b/roles/backup/tasks/iosxr.yml
@@ -5,4 +5,4 @@
   register: backup_location
 
 - debug:
-    msg: {{ backup_location }}
+    msg: "{{ backup_location }}"

--- a/roles/backup/tasks/junos.yml
+++ b/roles/backup/tasks/junos.yml
@@ -5,4 +5,4 @@
   register: backup_location
 
 - debug:
-    msg: {{ backup_location }}
+    msg: "{{ backup_location }}"

--- a/roles/backup/tasks/nxos.yml
+++ b/roles/backup/tasks/nxos.yml
@@ -5,4 +5,4 @@
   register: backup_location
 
 - debug:
-    msg: {{ backup_location }}
+    msg: "{{ backup_location }}"

--- a/roles/backup/tasks/vyos.yml
+++ b/roles/backup/tasks/vyos.yml
@@ -5,4 +5,4 @@
   register: backup_location
 
 - debug:
-    msg: {{ backup_location }}
+    msg: "{{ backup_location }}"


### PR DESCRIPTION
Some of the task files in the backups role will produce errors when run due to missing quotations. This fix has been tested and confirmed working in an OpenTLC environment.